### PR TITLE
Update Cerner Server URL

### DIFF
--- a/implementations.md
+++ b/implementations.md
@@ -12,9 +12,9 @@
   
   https://test.fhir.org/r3
   
-- Cerner (supports v0.1)
+- Cerner (supports v0.2)
   
-  https://fhir-open.stagingcerner.com/stu3/a758f80e-aa74-4118-80aa-98cc75846c76/Patient/$everything
+  https://fhir-open.stagingcerner.com/r4/a758f80e-aa74-4118-80aa-98cc75846c76/Patient/$export
   
 - ONC (supports v0.1)
   


### PR DESCRIPTION
Updating the Cerner FHIR Server test URL (and removing the old one as it's no longer up)