### PR TITLE
The status endpoint returns 202 while in progress

### DIFF
--- a/export.md
+++ b/export.md
@@ -162,7 +162,7 @@ Note: When requesting status, the client SHOULD use an ```Accept``` header for i
 
 #### Response - In-Progress Status
 
-- HTTP Status Code of ```102 Processing```
+- HTTP Status Code of ```202 Accepted```
 - Optionally, the server MAY return an ```X-Progress``` header with a text description of the status of the request that's less than 100 characters. The format of this description is at the server's discretion and may be a percentage complete value or a more general status such as "in progress". The client MAY parse the description, display it to the user, or log it.
 
 #### Response - Error Status


### PR DESCRIPTION
The reason is that `102` is an informational status header that cannot be used as status code (the real status code must be sent later in the same response). This is not very popular HTTP 1.1 feature that might not be well supported by server and client libraries. Also, it would only be applicable if we wanted to force the client to wait for the export to complete in single request. Instead, we should support polling the endpoint with multiple short requests over time, for which we need real HTTP status code.

For further information check the following references:
https://tools.ietf.org/html/rfc7231#section-6.2
https://tools.ietf.org/html/rfc2518#section-10.1
https://evertpot.com/http/102-processing